### PR TITLE
Rotate update

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ version = "0.1.3-dev"
 [deps]
 OpenFHE = "77ce9b8e-ecf5-45d1-bd8a-d31f384f2f95"
 
-
 [compat]
 OpenFHE = "0.1.5"
 julia = "1.8"

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.3-dev"
 [deps]
 OpenFHE = "77ce9b8e-ecf5-45d1-bd8a-d31f384f2f95"
 
+
 [compat]
 OpenFHE = "0.1.5"
 julia = "1.8"

--- a/src/openfhe.jl
+++ b/src/openfhe.jl
@@ -236,7 +236,7 @@ function rotate(sv::SecureVector{<:OpenFHEBackend}, shift; wrap_by)
             mask_rotated[first:last] .= 1
         else
             first = abs(shift) + 1
-            last = length(sv) + abs(shift)
+            last = length(sv)
             mask_rotated[first:last] .= 1
         end
         plaintext1 = OpenFHE.MakeCKKSPackedPlaintext(cc, mask_rotated)


### PR DESCRIPTION
I was adding new material to the paper and didn't understand why exactly this `last` index is correct in the `rotate` function for `wrap_by=:length` with `shift>0`. I expect that for both `shit>0` and `shift<0`, the sum of the two masks used after the first and second rotations should have ones exactly at the first `length(sv)` positions. I tested these changes on simulations, and they function exactly as before, but the code now appears more logical to me.