### PR TITLE
Update OpenFHE compatibility version to 0.2.0 instead of 0.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,5 +7,5 @@ authors = ["Michael Schlottke-Lakemper <michael@sloede.com>"]
 OpenFHE = "77ce9b8e-ecf5-45d1-bd8a-d31f384f2f95"
 
 [compat]
-OpenFHE = "0.1.14, 0.2"
+OpenFHE = "0.1.14, 0.2.0"
 julia = "1.10"


### PR DESCRIPTION
OpenFHE.jl released a new version 0.2.0.
SecureArithmetic registered it as 0.2. This mismatch leadsto the following error:

ERROR: LoadError: Unsatisfiable requirements detected for package OpenFHE [77ce9b8e]:
 OpenFHE [77ce9b8e] log:
 ├─possible versions are: 0.1.0-0.2.0 or uninstalled
 ├─restricted to versions 0.1.14-0.2 by project [0fbf5788], leaving only versions: 0.1.14-0.2.0
See https://github.com/hpsc-lab/SecureArithmetic.jl/actions/runs/24697243905/job/72232544333.
