### PR TITLE
Force OpenFHE version 0.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,5 +7,5 @@ authors = ["Michael Schlottke-Lakemper <michael@sloede.com>"]
 OpenFHE = "77ce9b8e-ecf5-45d1-bd8a-d31f384f2f95"
 
 [compat]
-OpenFHE = "0.1.14, 0.2"
+OpenFHE = "0.2"
 julia = "1.10"


### PR DESCRIPTION
Downgrade tests with OpenFHE due do version incompatability, see https://github.com/hpsc-lab/SecureArithmetic.jl/issues/102. This forces OpenFHE into v0.2, which uses openfhe_julia v0.6 which in turn uses openfhe.jll v1.5.1, and is thus consistently compatible.